### PR TITLE
Check the player entity and solve the spot-bug.

### DIFF
--- a/src/main/java/dimhol/gamelevels/BossRoomStrategy.java
+++ b/src/main/java/dimhol/gamelevels/BossRoomStrategy.java
@@ -118,11 +118,20 @@ public final class BossRoomStrategy implements RoomStrategy {
      * @param playerEntityWidth The
      * @param playerEntityHeight The
      */
-    private void generateAndPlacePlayer(final Set<Pair<Integer, Integer>> freeTiles, final List<Entity> entities,
+    private Entity generateAndPlacePlayer(final Set<Pair<Integer, Integer>> freeTiles, final List<Entity> entities,
                                         final int playerEntityWidth, final int playerEntityHeight) {
-        Entity player = createPlayer(freeTiles);
-        placeEntityAtRandomPosition(player, freeTiles, playerEntityWidth, playerEntityHeight);
-        entities.add(player);
+        Optional<Entity> existingPlayer = entities.stream()
+                .filter(entity -> entity.hasComponent(PositionComponent.class))
+                .findFirst();
+
+        if (existingPlayer.isPresent()) {
+            return existingPlayer.get();
+        } else {
+            Entity player = createPlayer(freeTiles);
+            placeEntityAtRandomPosition(player, freeTiles, playerEntityWidth, playerEntityHeight);
+            entities.add(player);
+            return player;
+        }
     }
 
     /**

--- a/src/main/java/dimhol/gamelevels/LevelManagerImpl.java
+++ b/src/main/java/dimhol/gamelevels/LevelManagerImpl.java
@@ -10,7 +10,6 @@ import dimhol.entity.factories.ItemFactory;
 import dimhol.gamelevels.map.MapLoader;
 import dimhol.gamelevels.map.MapLoaderImpl;
 import dimhol.gamelevels.map.TileMap;
-import dimhol.gamelevels.map.TileMapImpl;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -62,7 +61,7 @@ public class LevelManagerImpl implements LevelManager {
     public List<Entity> changeLevel(final List<Entity> entities) {
         currentLevel++;
         var player = savePlayer(entities);
-        return generateLevel(player);
+        return generateLevel(player, entities);
     }
 
     /**
@@ -101,7 +100,7 @@ public class LevelManagerImpl implements LevelManager {
      */
     @Override
     public TileMap getTileMap() {
-        return new TileMapImpl(this.tileMap);
+        return this.tileMap;
     }
 
     /**
@@ -139,7 +138,7 @@ public class LevelManagerImpl implements LevelManager {
      * @param player The player entity.
      * @return The list of entities for the new level.
      */
-    private List<Entity> generateLevel(final Optional<Entity> player) {
-        return this.determineRoomType().generate(player, getFreeTiles());
+    private List<Entity> generateLevel(final Optional<Entity> player, List<Entity> entities) {
+        return this.determineRoomType().generate(player, getFreeTiles(), entities);
     }
 }

--- a/src/main/java/dimhol/gamelevels/LevelManagerImpl.java
+++ b/src/main/java/dimhol/gamelevels/LevelManagerImpl.java
@@ -10,6 +10,7 @@ import dimhol.entity.factories.ItemFactory;
 import dimhol.gamelevels.map.MapLoader;
 import dimhol.gamelevels.map.MapLoaderImpl;
 import dimhol.gamelevels.map.TileMap;
+import dimhol.gamelevels.map.TileMapImpl;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -100,8 +101,17 @@ public class LevelManagerImpl implements LevelManager {
      */
     @Override
     public TileMap getTileMap() {
-        return this.tileMap;
+        // Create a defensive copy of the tileMap
+        TileMap tileMapCopy = new TileMapImpl(tileMap.getLayers() ,tileMap.getWidth(), tileMap.getHeight(),
+                tileMap.getTileWidth(), tileMap.getTileHeight());
+        for (int i = 0; i < tileMap.getWidth(); i++) {
+            for (int j = 0; j < tileMap.getHeight(); j++) {
+                tileMapCopy.setTile(i, j, tileMap.getTile(i, j));
+            }
+        }
+        return tileMapCopy;
     }
+
 
     /**
      * Retrieves the set of free tiles in the map.

--- a/src/main/java/dimhol/gamelevels/NormalRoomStrategy.java
+++ b/src/main/java/dimhol/gamelevels/NormalRoomStrategy.java
@@ -1,5 +1,6 @@
 package dimhol.gamelevels;
 
+import dimhol.components.PlayerComponent;
 import dimhol.components.PositionComponent;
 import dimhol.entity.Entity;
 import dimhol.entity.factories.EnemyFactory;
@@ -103,9 +104,18 @@ public class NormalRoomStrategy implements RoomStrategy {
         entities.add(gate);
     }
 
-    private void generatePlayer(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
-        Entity player = createAndPlacePlayer(freeTiles);
-        entities.add(player);
+    private Entity generatePlayer(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
+        Optional<Entity> existingEntity = entities.stream()
+                .filter(entity -> entity.hasComponent(PlayerComponent.class))
+                .findFirst();
+
+        if (existingEntity.isPresent()) {
+            return existingEntity.get();
+        } else {
+            Entity player = createAndPlacePlayer(freeTiles);
+            entities.add(player);
+            return player;
+        }
     }
 
     private void generateEnemies(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {

--- a/src/main/java/dimhol/gamelevels/NormalRoomStrategy.java
+++ b/src/main/java/dimhol/gamelevels/NormalRoomStrategy.java
@@ -72,29 +72,30 @@ public class NormalRoomStrategy implements RoomStrategy {
      * @return A list of generated entities.
      */
     @Override
-    public final List<Entity> generate(final Optional<Entity> entity, final Set<Pair<Integer, Integer>> freeTiles) {
+    public final List<Entity> generate(final Optional<Entity> entity, final Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
 
-        List<Entity> entities = new ArrayList<>();
+
+        List<Entity> newListOfEntities = new ArrayList<>();
 
         //Place the player:
-        generatePlayer(freeTiles, entities);
+        generatePlayer(freeTiles, entities, newListOfEntities);
 
         //Place the enemies:
-        generateEnemies(freeTiles, entities);
+        generateEnemies(freeTiles, newListOfEntities);
 
         System.out.println(freeTiles.size());
 
         //Place coins:
-        generateCoins(freeTiles, entities);
+        generateCoins(freeTiles, newListOfEntities);
 
         //Place heart:
-        generateHearts(freeTiles, entities);
+        generateHearts(freeTiles, newListOfEntities);
 
         //Place gate:
-        generateGate(freeTiles, entities);
+        generateGate(freeTiles, newListOfEntities);
 
 
-        return entities;
+        return newListOfEntities;
     }
 
     private void generateGate(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
@@ -104,17 +105,22 @@ public class NormalRoomStrategy implements RoomStrategy {
         entities.add(gate);
     }
 
-    private Entity generatePlayer(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
+    private void generatePlayer(Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities, List<Entity> newListOfEntities) {
         Optional<Entity> existingEntity = entities.stream()
                 .filter(entity -> entity.hasComponent(PlayerComponent.class))
                 .findFirst();
 
         if (existingEntity.isPresent()) {
-            return existingEntity.get();
+            var oldPlayer = existingEntity.get();
+            var position = (PositionComponent) oldPlayer.getComponent(PositionComponent.class);
+            oldPlayer.removeComponent(position);
+            var playerTiles = getRandomTile(freeTiles);
+            oldPlayer.addComponent(new PositionComponent(new Vector2D(playerTiles.getLeft().doubleValue(),
+                                                            playerTiles.getRight().doubleValue()), 1));
+            newListOfEntities.add(oldPlayer);
         } else {
             Entity player = createAndPlacePlayer(freeTiles);
-            entities.add(player);
-            return player;
+            newListOfEntities.add(player);
         }
     }
 

--- a/src/main/java/dimhol/gamelevels/RoomStrategy.java
+++ b/src/main/java/dimhol/gamelevels/RoomStrategy.java
@@ -22,5 +22,5 @@ public interface RoomStrategy {
      * @param freeTiles The set of available tiles within the room, where entities can be placed.
      * @return A List of entities generated for the game room.
      */
-    List<Entity> generate(Optional<Entity> entity, Set<Pair<Integer, Integer>> freeTiles);
+    List<Entity> generate(Optional<Entity> entity, Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities);
 }

--- a/src/main/java/dimhol/gamelevels/ShopRoomStrategy.java
+++ b/src/main/java/dimhol/gamelevels/ShopRoomStrategy.java
@@ -70,8 +70,7 @@ public class ShopRoomStrategy implements RoomStrategy {
         List<Entity> entities = new ArrayList<>();
 
         //Place the player:
-        Entity player = createAndPlacePlayer(freeTiles);
-        entities.add(player);
+        generatePlayer(freeTiles, entities);
 
         //Place the shop-keeper:
         Entity shopKeeper = createShopKeeper(freeTiles);
@@ -145,10 +144,19 @@ public class ShopRoomStrategy implements RoomStrategy {
      * @param freeTiles The set of available tiles where the player can be placed.
      * @return The created player entity.
      */
-    private Entity createAndPlacePlayer(final Set<Pair<Integer, Integer>> freeTiles) {
-        Entity player = createPlayer(freeTiles);
-        placeEntity(player, freeTiles);
-        return player;
+    private Entity generatePlayer(final Set<Pair<Integer, Integer>> freeTiles, List<Entity> entities) {
+        Optional<Entity> existingPlayer = entities.stream()
+                .filter(entity -> entity.hasComponent(PositionComponent.class))
+                .findFirst();
+
+        if (existingPlayer.isPresent()) {
+            return existingPlayer.get();
+        } else {
+            Entity player = createPlayer(freeTiles);
+            placeEntity(player, freeTiles);
+            entities.add(player);
+            return player;
+        }
     }
 
     /**


### PR DESCRIPTION
Now the player is created only if necessary, otherwise we get it from the list of entities. Also solves the spot-bug about the getter of the tile map, used into the level manager class.